### PR TITLE
Remove GATEWAY_URL requirement from s2i assemble script

### DIFF
--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -11,12 +11,6 @@ if [ -z "${NODE_ENV}" ]; then
 fi
 
 echo "NODE_ENV=${NODE_ENV}"
-echo "GATEWAY_URL=${GATEWAY_URL}"
-
-if [ -z "${GATEWAY_URL}" ]; then
-    echo "GATEWAY_URL must be set"
-    exit 1
-fi
 
 echo "---> Building Thermostat Web Client ..."
 NODE_ENV=development node ${NODE_ARGS} $(which npm-install-que)


### PR DESCRIPTION
The GATEWAY_URL is no longer required at build time by
the web-client. The assemble script does not need to
fail if it isn't set